### PR TITLE
Fix the annoying prompt for theme safety on reloading my own theme

### DIFF
--- a/init.org
+++ b/init.org
@@ -257,8 +257,7 @@ Install theme from github.
     :straight (brew-theme :type git :repo "git@github.com:rlister/brew-theme.git")
     :config
     (add-to-list 'custom-theme-load-path (expand-file-name  "straight/repos/brew-theme" straight-base-dir))
-    (load-theme 'brew t)
-    )
+    (brew-theme))
 #+end_src
 
 * Font

--- a/init.org
+++ b/init.org
@@ -242,7 +242,15 @@ Turn on ~use-package~ integration:
 
 * Theme
 
-Load my theme.
+Load my theme without prompting for safety.
+
+#+begin_src emacs-lisp
+  (defun brew-theme ()
+    (interactive)
+    (load-theme 'brew t))
+#+end_src
+
+Install theme from github.
 
 #+begin_src emacs-lisp
   (use-package brew-theme


### PR DESCRIPTION
Prompt for safety unloads the theme first, giving me a blinding white screen until I can type `p`.

Adding theme to list of safe themes means taking a sha, so this is a simpler workaround.